### PR TITLE
fix(publication): Publication Page HTML Structure Issue Impacting Scraping

### DIFF
--- a/publications/pubs-current.html
+++ b/publications/pubs-current.html
@@ -10951,10 +10951,11 @@
   Solid State Communications <b>28</b> (7):501–504 (1978)
 </div>
 
-<div class="csl-block"><b>122</b>. Mechanisms of gas-phase and liquid-phase ozonolysis</div>
-    <div class="csl-block">L.B. Harding and W.A. Goddard III</div>
-    J. Am. Chem. Soc. <b>100</b> (23):7180–7188 (1978) DOI:<a href="https://doi.org/10.1021/ja00491a010">10.1021/ja00491a010</a>
-    <div class="csl-block"><a href="https://resolver.caltech.edu/CaltechAUTHORS:20230607-256274000.3">https://resolver.caltech.edu/CaltechAUTHORS:20230607-256274000.3</a></div>
+<div class="csl-entry" style="margin-bottom: 1em;">
+  <div class="csl-block"><b>122</b>. Mechanisms of gas-phase and liquid-phase ozonolysis</div>
+  <div class="csl-block">L.B. Harding and W.A. Goddard III</div>
+  J. Am. Chem. Soc. <b>100</b> (23):7180–7188 (1978) DOI:<a href="https://doi.org/10.1021/ja00491a010">10.1021/ja00491a010</a>
+  <div class="csl-block"><a href="https://resolver.caltech.edu/CaltechAUTHORS:20230607-256274000.3">https://resolver.caltech.edu/CaltechAUTHORS:20230607-256274000.3</a></div>
 </div>
 
 <div class="csl-entry" style="margin-bottom: 1em;">


### PR DESCRIPTION
### Background:

The publication data for [MSC Website ](https://www.wag.caltech.edu) is sourced from the HTML on [this page](https://caltech-msc.github.io/publications/pubs-current.html). However, one publication entry (the one corresponding to paper **#122**) has an element structure problem. This inconsistency causes the crawler at [https://www.wag.caltech.edu/publications](https://www.wag.caltech.edu/publications) to fail to scrape the affected publication correctly.

When running the following debugging script in the browser console on [`/publications/pubs-current.html`](https://caltech-msc.github.io/publications/pubs-current.html), the output shows that entry index **122** is missing:

```js
const findMissing = (arr, start = 1) => {
    let m = [], e = start;
    arr.slice().sort((a, b) => a - b).forEach(n => {
        while (n > e) m.push(e++);
        e = n + 1;
    });
    return m;
};

const nums = [...document.querySelectorAll('.csl-block > b')]
    .map(e => parseInt(e.textContent, 10))
    .filter(n => !isNaN(n));
findMissing(nums).forEach(n => console.log(`Missing number: ${n}`));

const entries = document.querySelectorAll('.csl-entry');
console.log(`Total .csl-entry count: ${entries.length}`);

const en = [...entries]
    .map(e => {
        const b = e.querySelector('.csl-block > b');
        return b ? parseInt(b.textContent, 10) : null;
    })
    .filter(n => n !== null);
findMissing(en).forEach(n => console.log(`Missing entry index: ${n}`));
```

The console output confirmed:

```
Missing entry index: 122
```

### Issue Description:

- **Problematic HTML Structure:** The affected publication entry is missing the required outer `<div class="csl-entry">` wrapper. This deviation from the standard structure causes the web scraper to overlook this entry.
- **Scraping Failure:** Due to the missing wrapper, the crawler at [https://www.wag.caltech.edu/publications](https://www.wag.caltech.edu/publications) fails to correctly identify and extract the publication with index **122**.

### Changes Made:

- **Add Missing Outer Element:** Introduce the `<div class="csl-entry">` wrapper around the problematic publication entry to ensure a consistent structure.
- **Correct Structural Errors:** Update the HTML markup for the affected publication to align with the standard format used throughout the page.